### PR TITLE
Update dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.9.0
-homeassistant==2025.2.4
-pip>=21.3.1
+homeassistant==2025.5.3
+pip>=25.1
 ruff==0.11.2


### PR DESCRIPTION
Bump homeassistant to version 2025.5.3 and pip to >=25.1. These updates ensure compatibility with the latest features and improvements.
---
This upgrade fixes the “response[‘data’].copy” error. The reason for this was that the current production core version and the core version in the integration were too different.

Background:
The “response[‘data’].copy()” error rendered the integration unusable after the correct login details had been set, as no data could be received from Ecoflow.