### PR TITLE
Fix: use Path(__file__).parent for variant JSON file to avoid FileNotFound

### DIFF
--- a/custom_components/powerocean/ecoflow.py
+++ b/custom_components/powerocean/ecoflow.py
@@ -184,7 +184,7 @@ class Ecoflow:
         # Path relative to this file (ecoflow.py)
         base_path = Path(__file__).parent
         self.datapointfile = base_path / "variants" / f"{self.ecoflow_variant}.json"
-
+        self.options = options # Store Home Assistant instance
 
     def get_device(self) -> dict:
         """Get device info."""


### PR DESCRIPTION
This PR fixes a FileNotFoundError when loading variant JSON files by using
a path relative to ecoflow.py instead of a working-directory based path.
Tested on Home Assistant 2025.9 with PowerOcean variant 83.